### PR TITLE
Improve time sync.

### DIFF
--- a/components/lwip/apps/sntp/sntp.c
+++ b/components/lwip/apps/sntp/sntp.c
@@ -34,27 +34,30 @@ inline void sntp_set_sync_status(sntp_sync_status_t sync_status)
 
 void __attribute__((weak)) sntp_sync_time(struct timeval *tv)
 {
+    struct timeval tv_now;
+    gettimeofday(&tv_now, NULL);
+    int64_t cpu_time = (int64_t)tv_now.tv_sec * 1000000L + (int64_t)tv_now.tv_usec;
+    int64_t sntp_time = (int64_t)tv->tv_sec * 1000000L + (int64_t)tv->tv_usec;
+    int64_t delta = sntp_time - cpu_time;
     if (sntp_sync_mode == SNTP_SYNC_MODE_IMMED) {
         settimeofday(tv, NULL);
         sntp_set_sync_status(SNTP_SYNC_STATUS_COMPLETED);
     } else if (sntp_sync_mode == SNTP_SYNC_MODE_SMOOTH) {
-        struct timeval tv_now;
-        gettimeofday(&tv_now, NULL);
-        int64_t cpu_time = (int64_t)tv_now.tv_sec * 1000000L + (int64_t)tv_now.tv_usec;
-        int64_t sntp_time = (int64_t)tv->tv_sec * 1000000L + (int64_t)tv->tv_usec;
-        int64_t delta = sntp_time - cpu_time;
         struct timeval tv_delta = { .tv_sec = delta / 1000000L, .tv_usec = delta % 1000000L };
         if (adjtime(&tv_delta, NULL) == -1) {
-            ESP_LOGD(TAG, "Function adjtime don't update time because the error is very big");
+            ESP_LOGD(TAG, "Time error too big, smooth adjustment not feasible!");
+            // Stop ongoing smooth adjustment
+            tv_delta.tv_sec = tv_delta.tv_usec = 0;
+            adjtime(&tv_delta, NULL);
+            // Directly set the time
             settimeofday(tv, NULL);
-            ESP_LOGD(TAG, "Time was synchronized through settimeofday");
             sntp_set_sync_status(SNTP_SYNC_STATUS_COMPLETED);
         } else {
             sntp_set_sync_status(SNTP_SYNC_STATUS_IN_PROGRESS);
         }
     }
     if (time_sync_notification_cb) {
-        time_sync_notification_cb(tv);
+        time_sync_notification_cb(tv, delta);
     }
 }
 

--- a/components/lwip/include/apps/sntp/sntp.h
+++ b/components/lwip/include/apps/sntp/sntp.h
@@ -60,7 +60,7 @@ typedef enum {
  *
  * @param tv Time received from SNTP server.
  */
-typedef void (*sntp_sync_time_cb_t) (struct timeval *tv);
+typedef void (*sntp_sync_time_cb_t) (struct timeval *tv, int64_t delta);
 
 /**
  * @brief This function updates the system time.

--- a/components/newlib/platform_include/time.h
+++ b/components/newlib/platform_include/time.h
@@ -29,6 +29,10 @@ int clock_settime(clockid_t clock_id, const struct timespec *tp);
 int clock_gettime(clockid_t clock_id, struct timespec *tp);
 int clock_getres(clockid_t clock_id, struct timespec *res);
 
+// Call this function regularly to smoothly apply correction to the system clock.
+// Recommended interval between 1 and 10 sec.
+uint64_t adjust_boot_time(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Simplify various time adjustment logic;
Make SNTP time sync event report the time delta;
Export `adjust_boot_time()` so user code can drive time adjustment without needing to call `sntp_get_sync_status()`.