### PR TITLE
Misc improvements to OTA related features.

### DIFF
--- a/components/app_update/CMakeLists.txt
+++ b/components/app_update/CMakeLists.txt
@@ -11,11 +11,12 @@ idf_build_get_property(project_ver PROJECT_VER)
 idf_build_get_property(project_name PROJECT_NAME)
 string(SUBSTRING "${project_ver}" 0 31 PROJECT_VER_CUT)
 string(SUBSTRING "${project_name}" 0 31 PROJECT_NAME_CUT)
+string(TIMESTAMP CURRENT_TIME)
 
 set_source_files_properties(
     SOURCE "esp_app_desc.c" "esp_app_desc.c"
     PROPERTIES COMPILE_DEFINITIONS
-    "PROJECT_VER=\"${PROJECT_VER_CUT}\"; PROJECT_NAME=\"${PROJECT_NAME_CUT}\"")
+    "BUILD_TIMESTAMP=\"${CURRENT_TIME}\"; PROJECT_VER=\"${PROJECT_VER_CUT}\"; PROJECT_NAME=\"${PROJECT_NAME_CUT}\"")
 
 if(NOT BOOTLOADER_BUILD)
     partition_table_get_partition_info(otadata_offset "--partition-type data --partition-subtype ota" "offset")

--- a/components/app_update/component.mk
+++ b/components/app_update/component.mk
@@ -50,5 +50,5 @@ ifndef IS_BOOTLOADER_BUILD
         $(shell echo $(NEW_DEFINES) > $(TMP_DEFINES); rm -f esp_app_desc.o;)
     endif
 
-    esp_app_desc.o: CPPFLAGS += -D PROJECT_VER=\""$(PROJECT_VER_CUT)"\" -D PROJECT_NAME=\""$(PROJECT_NAME_CUT)"\"
+    esp_app_desc.o: CPPFLAGS += -D BUILD_TIMESTAMP="$(shell date)" -D PROJECT_VER=\""$(PROJECT_VER_CUT)"\" -D PROJECT_NAME=\""$(PROJECT_NAME_CUT)"\"
 endif # IS_BOOTLOADER_BUILD

--- a/components/bootloader_support/include/esp_image_format.h
+++ b/components/bootloader_support/include/esp_image_format.h
@@ -37,7 +37,7 @@ typedef enum {
 } esp_image_spi_mode_t;
 
 /* SPI flash clock frequency */
-enum {
+typedef enum {
     ESP_IMAGE_SPI_SPEED_40M,
     ESP_IMAGE_SPI_SPEED_26M,
     ESP_IMAGE_SPI_SPEED_20M,


### PR DESCRIPTION
- Fix `esp_app_desc` reading for ESP8266 firmware image;
- Add build parameter to make esp_app_desc gets rebuilt (so that images will have correct date and time);
- Add missing `typedef` in esp_image_format.h